### PR TITLE
S3: Add support for region, storage class and non-AWS providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,13 @@ Processes images and finds thumbnails for Feedbin
 * `AWS_SECRET_ACCESS_KEY` - You AWS secret access key
 * `AWS_S3_BUCKET` - The bucket to upload the thumbnails to
 * `REDIS_URL` - The URL to the Redis instance used by the main Feedbin instance
+* `AWS_S3_REGION` - The AWS region of your bucket
 
-You can technically also use Minio or another S3 alternative by editing the parameters in [lib/s3_pool.rb](lib/s3_pool.rb). The Minio cookbook has [an example](https://github.com/minio/cookbook/blob/master/docs/fog-aws-for-ruby-with-minio.md) with the necessary parameters.
+Optional variables, you might need these for non-AWS providers:
+
+* `AWS_S3_HOST` - domain of your endpoint
+* `AWS_S3_ENDPOINT` - Same but with the scheme and port
+* `AWS_S3_PATH_STYLE` - Need to be set to `true` for Minio
 
 ### Setup
 Clone the repo and install dependencies:

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -32,7 +32,7 @@ class Upload
     {
       "Cache-Control" => "max-age=315360000, public",
       "Expires" => "Sun, 29 Jun 2036 17:48:34 GMT",
-      "x-amz-storage-class" => "REDUCED_REDUNDANCY"
+      "x-amz-storage-class" => ENV["AWS_S3_STORAGE_CLASS"] || "REDUCED_REDUNDANCY",
     }
   end
 

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -20,7 +20,7 @@ module Helpers
     {
       "Cache-Control" => "max-age=315360000, public",
       "Expires" => "Sun, 29 Jun 2036 17:48:34 GMT",
-      "x-amz-storage-class" => "REDUCED_REDUNDANCY"
+      "x-amz-storage-class" => ENV["AWS_S3_STORAGE_CLASS"] || "REDUCED_REDUNDANCY",
     }
   end
 

--- a/lib/s3_pool.rb
+++ b/lib/s3_pool.rb
@@ -3,6 +3,10 @@ S3_POOL = ConnectionPool.new(size: 10, timeout: 5) do
     provider: "AWS",
     aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
     aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-    persistent: true
+    region: ENV["AWS_S3_REGION"] || "us-east-1",
+    host: ENV["AWS_S3_HOST"] || "s3.amazonaws.com",
+    endpoint: ENV["AWS_S3_ENDPOINT"] || nil,
+    path_style: ENV["AWS_S3_PATH_STYLE"] || false,
+    persistent: true,
   )
 end


### PR DESCRIPTION
Following https://github.com/feedbin/feedbin/pull/396, so that feedbin is fully provider agnostic!