### PR TITLE
Allow specifying different S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Processes images and finds thumbnails for Feedbin
 
 * `AWS_ACCESS_KEY_ID` - Your AWS access key ID
 * `AWS_SECRET_ACCESS_KEY` - You AWS secret access key
-* `AWS_S3_BUCKET` - The bucket to upload the thumbnails to
+* `AWS_S3_BUCKET_IMAGES` (or `AWS_S3_BUCKET` if not set) - The bucket to upload the thumbnails to
 * `REDIS_URL` - The URL to the Redis instance used by the main Feedbin instance
 * `FACEBOOK_ACCESS_TOKEN` - Needed to access Instagram images
 

--- a/app/download_cache.rb
+++ b/app/download_cache.rb
@@ -56,7 +56,7 @@ class DownloadCache
   def copy_image
     url = URI.parse(storage_url)
     source_object_name = url.path[1..-1]
-    Fog::Storage.new(STORAGE_OPTIONS).copy_object(ENV["AWS_S3_BUCKET"], source_object_name, ENV["AWS_S3_BUCKET"], image_name, storage_options)
+    Fog::Storage.new(STORAGE_OPTIONS).copy_object(AWS_S3_BUCKET_IMAGES, source_object_name, AWS_S3_BUCKET_IMAGES, image_name, storage_options)
     final_url = url.path = "/#{image_name}"
     url.to_s
   rescue Excon::Error::NotFound

--- a/app/jobs/upload_image.rb
+++ b/app/jobs/upload_image.rb
@@ -22,7 +22,7 @@ class UploadImage
 
   def upload
     File.open(@image_path) do |file|
-      response = Fog::Storage.new(STORAGE_OPTIONS).put_object(ENV["AWS_S3_BUCKET"], image_name, file, storage_options)
+      response = Fog::Storage.new(STORAGE_OPTIONS).put_object(AWS_S3_BUCKET_IMAGES, image_name, file, storage_options)
       URI::HTTPS.build(
         host: response.data[:host],
         path: response.data[:path]

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1,4 +1,6 @@
 module Helpers
+  AWS_S3_BUCKET_IMAGES = ENV["AWS_S3_BUCKET_IMAGES"] || ENV["AWS_S3_BUCKET"]
+
   def preset
     OpenStruct.new(IMAGE_PRESETS[@preset_name.to_sym])
   end


### PR DESCRIPTION
This allows sharing env between components while keeping images in its own bucket.

Resolves #15.